### PR TITLE
Fix bug in physics engine

### DIFF
--- a/air_hockey/collision.py
+++ b/air_hockey/collision.py
@@ -10,8 +10,8 @@ class Collision(object):
         inverse_mass_0 = bodies[0].get_inverse_mass()
         inverse_mass_1 = bodies[1].get_inverse_mass()
 
-        relative_velocity  = velocity_0
-        relative_velocity -= velocity_1
+        relative_velocity  = velocity_0.copy()
+        relative_velocity -= velocity_1.copy()
         separating_velocity = relative_velocity.dot(normal)
         if separating_velocity >= 0.0: return
 
@@ -22,7 +22,7 @@ class Collision(object):
         total_inverse_mass  = inverse_mass_0
         total_inverse_mass += inverse_mass_1
 
-        impulse = delta_velocity * total_inverse_mass # FIXED BUG : Textbook had '/' instead of '*'
+        impulse = delta_velocity / total_inverse_mass
         impulse_per_inverse_mass = normal * impulse
 
         new_velocity_0 = velocity_0 + impulse_per_inverse_mass *  inverse_mass_0


### PR DESCRIPTION
There was a bug related to deep and shallow copies in the velocities, that was masked by the multiplication (instead of division) of `total_inverse_mass`.
I double checked the textbook because collisions seemed a bit off and found that the bug probably happened when translating the example code from the book into Python.
Was suspecting from the line: ` impulse = delta_velocity * total_inverse_mass # FIXED BUG : Textbook had '/' instead of '*'` because physical units don't add up in this equation.
Great simulator by the way!